### PR TITLE
refactor: Split matchmaking service

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -9,7 +9,7 @@ class PlayersController < ApplicationController
   def create
     round = current_user.tournament_rounds.find(params[:round_id])
     authorize round, :assign_players?
-    players = MatchmakingService.new(round).call
+    players = MatchmakingService.new.call(round)
     render json: PlayerSerializer.render(players, root: :players),
            status: :created
   end

--- a/app/services/assigners/new_opponents_assigner.rb
+++ b/app/services/assigners/new_opponents_assigner.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Assigners
+  class NewOpponentsAssigner
+    def call(round)
+      elimination_rounds = round.tournament.rounds
+                             .where(competitors_limit: round.competitors_limit, tables_count: round.tables_count)
+                             .all
+      elimination_index = elimination_rounds.find_index(round)
+
+      return false unless elimination_index.positive?
+
+      round_competitor_ids(elimination_rounds, elimination_index)
+    end
+
+    private
+
+    def round_competitor_ids(elimination_rounds, elimination_index)
+      competitor_ids = elimination_rounds.first.players.pluck(:competitor_id)
+
+      group_size = Math.sqrt(competitor_ids.size).ceil
+      matrix = competitor_ids.in_groups_of(group_size)
+
+      (0..(group_size - 1)).inject([]) do |next_competitor_ids, column|
+        (0..(matrix.size - 1)).inject(next_competitor_ids) do |acc, row|
+          modified_column = (column + row * elimination_index) % group_size
+          id = matrix[row][modified_column]
+          acc.push(id) unless id.nil?
+        end
+      end
+    end
+  end
+end

--- a/app/services/assigners/random_assigner.rb
+++ b/app/services/assigners/random_assigner.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Assigners
+  class RandomAssigner
+    def call(round)
+      return false unless valid?(round)
+
+      round.tournament.competitors
+        .confirmed
+        .limit(round.competitors_limit)
+        .pluck(:id)
+        .shuffle!
+    end
+
+    private
+
+    def valid?(round)
+      round.id == round.tournament.rounds.first.id
+    end
+  end
+end

--- a/app/services/assigners/swiss_assigner.rb
+++ b/app/services/assigners/swiss_assigner.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Assigners
+  class SwissAssigner
+    def call(round)
+      round.tournament.results
+        .limit(round.competitors_limit)
+        .pluck(:competitor_id)
+    end
+  end
+end

--- a/app/services/matchmaking_service.rb
+++ b/app/services/matchmaking_service.rb
@@ -1,89 +1,31 @@
 # frozen_string_literal: true
 
-# TODO: Split assignment into specific implementations and clean up?
 class MatchmakingService
-  def initialize(round)
-    @round = round
-    @tournament = round.tournament
-    @players = []
-  end
-
-  def call
-    clear_round
-    if first_round?
-      random_assignment
-    elsif elimination_round?
-      new_opponents_assignment
-    else
-      swiss_assignment
-    end
-    @players
+  def call(round)
+    clear_round(round)
+    create_players(round)
   end
 
   private
 
-  def clear_round
-    @round.players.destroy_all
+  def clear_round(round)
+    round.players.destroy_all
   end
 
-
-  def first_round?
-    @round.id == @tournament.rounds.first.id
-  end
-
-  def random_assignment
-    competitor_ids = @tournament.competitors
-                       .confirmed
-                       .limit(@round.competitors_limit)
-                       .pluck(:id)
-    competitor_ids.shuffle!
-    create_players(competitor_ids)
-  end
-
-
-  def elimination_round?
-    @elimination_rounds = @tournament.rounds
-                            .where(competitors_limit: @round.competitors_limit, tables_count: @round.tables_count)
-                            .all
-    @elimination_index = @elimination_rounds.find_index(@round)
-    @elimination_index.positive?
-  end
-
-  def new_opponents_assignment
-    competitor_ids = @elimination_rounds.first.players.pluck(:competitor_id)
-
-    group_size = Math.sqrt(competitor_ids.size).ceil
-    matrix = competitor_ids.in_groups_of(group_size)
-    next_competitor_ids = []
-
-    (0..(group_size - 1)).each do |column|
-      (0..(matrix.size - 1)).each do |row|
-        modified_column = (column + row * @elimination_index) % group_size
-        id = matrix[row][modified_column]
-        next_competitor_ids.push(id) unless id.nil?
-      end
-    end
-
-    create_players(next_competitor_ids)
-  end
-
-
-  def swiss_assignment
-    competitor_ids = @tournament.results
-                       .limit(@round.competitors_limit)
-                       .pluck(:competitor_id)
-    create_players(competitor_ids)
-  end
-
-
-  def create_players(competitor_ids)
-    competitor_ids.in_groups(@round.tables_count, false).each_with_index do |group, idx|
-      group.each do |competitor_id|
-        @players << @round.players.create!(
+  def create_players(round)
+    competitor_ids(round).in_groups(round.tables_count, false).each_with_index.inject([]) do |players, (group, idx)|
+      group.inject(players) do |acc, competitor_id|
+        acc << round.players.create!(
           competitor_id: competitor_id,
           table_number: idx + 1
         )
       end
     end
+  end
+
+  def competitor_ids(round)
+    Assigners::RandomAssigner.new.call(round) ||
+      Assigners::NewOpponentsAssigner.new.call(round) ||
+      Assigners::SwissAssigner.new.call(round)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
     root 'tournaments#index'
 
     use_doorkeeper do
-      skip_controllers :applications, :authorizations, :authorized_applications
+      skip_controllers :authorizations
     end
 
     resources :users, only: :none do

--- a/spec/requests/players_spec.rb
+++ b/spec/requests/players_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Players', type: :request do
   describe 'POST /players' do
     context 'with first Round of a Tournament' do
       it 'randomizes Players' do
-        expect_any_instance_of(MatchmakingService).to receive(:random_assignment).and_call_original
+        expect_any_instance_of(Assigners::RandomAssigner).to receive(:call).and_call_original
         expect do
           post players_path,
                headers: auth_headers,
@@ -36,7 +36,7 @@ RSpec.describe 'Players', type: :request do
       let(:second_round) { create(:round, tournament: tournament) }
 
       it "assigns Players who haven't met yet" do
-        expect_any_instance_of(MatchmakingService).to receive(:new_opponents_assignment).and_call_original
+        expect_any_instance_of(Assigners::NewOpponentsAssigner).to receive(:call).and_call_original
         expect do
           post players_path,
                headers: auth_headers,
@@ -60,7 +60,7 @@ RSpec.describe 'Players', type: :request do
       let(:second_round) { create(:round, competitors_limit: 8, tournament: tournament) }
 
       it 'assigns Players according to their results' do
-        expect_any_instance_of(MatchmakingService).to receive(:swiss_assignment).and_call_original
+        expect_any_instance_of(Assigners::SwissAssigner).to receive(:call).and_call_original
         expect do
           post players_path,
                headers: auth_headers,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
<!--- Title must follow conventional commits. -->
<!--- See: -->
<!--- - https://www.conventionalcommits.org/ -->
<!--- - https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

## Description

Pass variables instead of `@storing` them in the instance. Separate logic for each assignment type. 